### PR TITLE
Update amm.move

### DIFF
--- a/sources/amm.move
+++ b/sources/amm.move
@@ -1,4 +1,4 @@
-module amm::uniswapV2 {
+module amm::uniswapv2 {
     use std::type_name::{Self, TypeName};
     use sui::balance::{Self, Balance, Supply};
     use sui::coin::{Self, Coin};
@@ -7,44 +7,62 @@ module amm::uniswapV2 {
     use std::ascii;
     use sui::table::{Self, Table};
     use sui::tx_context::sender;
+    use core::convert::TryInto;
 
     /* === errors === */
 
-    /// The input amount is zero.
-    const EZeroInput: u64 = 0;
-    /// Pool pair coin types must be ordered alphabetically (`A` < `B`) and mustn't be equal.
-    const EInvalidPair: u64 = 1;
-    /// Pool for this pair already exists.
-    const EPoolAlreadyExists: u64 = 2;
-    /// The pool balance differs from the acceptable.
-    const EExcessiveSlippage: u64 = 3;
-    /// There's no liquidity in the pool.
-    const ENoLiquidity: u64 = 4;
+    enum Error {
+        ZeroInput,
+        InvalidPair,
+        PoolAlreadyExists,
+        ExcessiveSlippage,
+        NoLiquidity,
+        DivisionByZero,
+    }
 
     /* === constants === */
 
-    const LP_FEE_BASE: u64 = 10000;
+    const LP_FEE_BASE: u64 = 10_000;
 
     /* === math === */
 
     /// Calculates (a * b) / c. Errors if result doesn't fit into u64.
-    fun muldiv(a: u64, b: u64, c: u64): u64 {
-        ((((a as u128) * (b as u128)) / (c as u128)) as u64)
+    fun muldiv(a: u64, b: u64, c: u64): Result<u64, Error> {
+        let mul_result = (a as u128).checked_mul(b as u128);
+        let result = mul_result.and_then(|prod| prod.checked_div(c as u128));
+        result.map(|value| value.try_into().unwrap_or(Err(Error::DivisionByZero)))
+            .unwrap_or(Err(Error::DivisionByZero))
     }
 
     /// Calculates ceil_div((a * b), c). Errors if result doesn't fit into u64.
-    fun ceil_muldiv(a: u64, b: u64, c: u64): u64 {
-        (ceil_div_u128((a as u128) * (b as u128), (c as u128)) as u64)
+    fun ceil_muldiv(a: u64, b: u64, c: u64): Result<u64, Error> {
+        let mul_result = (a as u128).checked_mul(b as u128);
+        let result = mul_result.and_then(|prod| {
+            let divisor = c as u128;
+            let quotient = (prod + divisor - 1) / divisor;
+            if quotient > u64::max_value() as u128 {
+                None
+            } else {
+                Some(quotient as u64)
+            }
+        });
+        result.map(|value| Ok(value))
+            .unwrap_or(Err(Error::DivisionByZero))
     }
 
     /// Calculates sqrt(a * b).
-    fun mulsqrt(a: u64, b: u64): u64 {
-        (math::sqrt_u128((a as u128) * (b as u128)) as u64)
-    }
-
-    /// Calculates ceil(a / b).
-    fun ceil_div_u128(a: u128, b: u128): u128 {
-        if (a == 0) 0 else (a - 1) / b + 1
+    fun mulsqrt(a: u64, b: u64): Result<u64, Error> {
+        let mul_result = (a as u128).checked_mul(b as u128);
+        let result = mul_result.and_then(|prod| {
+            let sqrt = prod.sqrt();
+            if sqrt > u64::max_value() as u128 {
+                None
+            } else {
+                Some(sqrt as u64)
+            }
+        });
+        result.map(|value| Ok(value))
+            .unwrap_or(Err(Error::DivisionByZero))
     }
 
     /* === events === */
@@ -123,19 +141,24 @@ module amm::uniswapV2 {
         b: TypeName
     }
 
-    fun add_pool<A, B>(factory: &mut Factory) {
-        let a = type_name::get<A>();
-        let b = type_name::get<B>();
-        assert!(cmp_type_names(&a, &b) == 0, EInvalidPair);
-
-        let item = PoolItem{ a, b };
-        assert!(table::contains(&factory.table, item) == false, EPoolAlreadyExists);
-
-        table::add(&mut factory.table, item, true)
+    fun add_pool<A, B>(factory: &mut Factory) -> Result<(), Error> {
+        let a = type_name::get::<A>();
+        let b = type_name::get::<B>();
+        if cmp_type_names(&a, &b) != 0 {
+            Err(Error::InvalidPair)
+        } else {
+            let item = PoolItem{ a, b };
+            if table::contains(&factory.table, item) {
+                Err(Error::PoolAlreadyExists)
+            } else {
+                table::add(&mut factory.table, item, true);
+                Ok(())
+            }
+        }
     }
 
     // returns: 0 if a < b; 1 if a == b; 2 if a > b
-    public fun cmp_type_names(a: &TypeName, b: &TypeName): u8 {
+    public fun cmp_type_names(a: &TypeName, b: &TypeName) -> u8 {
         let bytes_a = ascii::as_bytes(type_name::borrow_string(a));
         let bytes_b = ascii::as_bytes(type_name::borrow_string(b));
 
@@ -144,24 +167,20 @@ module amm::uniswapV2 {
 
         let mut i = 0;
         let n = math::min(len_a, len_b);
-        while (i < n) {
+        while i < n {
             let a = *vector::borrow(bytes_a, i);
             let b = *vector::borrow(bytes_b, i);
-
-            if (a < b) {
+            if a < b {
                 return 0
-            };
-            if (a > b) {
+            } else if a > b {
                 return 2
-            };
-            i = i + 1;
+            }
+            i += 1;
         };
 
-        if (len_a == len_b) {
-            return 1
-        };
-
-        return if (len_a < len_b) {
+        if len_a == len_b {
+            1
+        } else if len_a < len_b {
             0
         } else {
             2
@@ -178,398 +197,245 @@ module amm::uniswapV2 {
         transfer::share_object(factory);
     }
 
-    public fun create_pool<A, B>(factory: &mut Factory, init_a: Balance<A>, init_b: Balance<B>, ctx: &mut TxContext): Balance<LP<A, B>> {
-        assert!(balance::value(&init_a) > 0 && balance::value(&init_b) > 0, EZeroInput);
+    pub fun create_pool<A, B>(factory: &mut Factory, init_a: Balance<A>, init_b: Balance<B>, ctx: &mut TxContext) -> Result<Balance<LP<A, B>>, Error> {
+        if balance::value(&init_a) == 0 || balance::value(&init_b) == 0 {
+            return Err(Error::ZeroInput);
+        }
 
-        add_pool<A, B>(factory);
+        let result = add_pool::<A, B>(factory).map(|_| {
+            // create pool
+            let mut pool = Pool::<A, B> {
+                id: object::new(ctx),
+                balance_a: init_a,
+                balance_b: init_b,
+                lp_supply: balance::create_supply(LP::<A, B> {}),
+                fee_points: 30, // 0.3%
+            };
 
-        // create pool
-        let mut pool = Pool<A, B> {
-            id: object::new(ctx),
-            balance_a: init_a,
-            balance_b: init_b,
-            lp_supply: balance::create_supply(LP<A, B> {}),
-            fee_points: 30, // 0.3%
-        };
+            // mint initial lp tokens
+            let lp_amount = mulsqrt(balance::value(&pool.balance_a), balance::value(&pool.balance_b))?;
+            let lp_balance = balance::increase_supply(&mut pool.lp_supply, lp_amount)?;
 
-        // mint initial lp tokens
-        let lp_amount = mulsqrt(balance::value(&pool.balance_a), balance::value(&pool.balance_b));
-        let lp_balance = balance::increase_supply(&mut pool.lp_supply, lp_amount);
+            event::emit(PoolCreated {
+                pool_id: object::id(&pool),
+                a: type_name::
+ get::(), b: type_name::get::(), init_a: balance::value(&pool.balance_a), init_b: balance::value(&pool.balance_b), lp_minted: lp_amount, });
 
-        event::emit(PoolCreated {
-            pool_id: object::id(&pool),
-            a: type_name::get<A>(),
-            b: type_name::get<B>(),
-            init_a: balance::value(&pool.balance_a), // test error?
-            init_b: balance::value(&pool.balance_b),
-            lp_minted: lp_amount,
-        });
-
+ 
         transfer::share_object(pool);
+        Ok(lp_balance)
+    });
 
-        lp_balance
+    result.unwrap_or_else(|err| Err(err))
+}
+
+pub fun add_liquidity<A, B>(pool: &mut Pool<A, B>, mut input_a: Balance<A>, mut input_b: Balance<B>, min_lp_out: u64) -> Result<(Balance<A>, Balance<B>, Balance<LP<A, B>>), Error> {
+    if balance::value(&input_a) == 0 || balance::value(&input_b) == 0 {
+        return Err(Error::ZeroInput);
     }
 
-    public fun add_liquidity<A, B>(pool: &mut Pool<A, B>, mut input_a: Balance<A>, mut input_b: Balance<B>, min_lp_out: u64): (Balance<A>, Balance<B>, Balance<LP<A, B>>) {
-        assert!(balance::value(&input_a) > 0 && balance::value(&input_b) > 0, EZeroInput);
+    // calculate the deposit amounts
+    let input_a_mul_pool_b = muldiv(balance::value(&input_a), balance::value(&pool.balance_b), u64::max_value())?;
+    let input_b_mul_pool_a = muldiv(balance::value(&input_b), balance::value(&pool.balance_a), u64::max_value())?;
 
-        // calculate the deposit amounts
-        let input_a_mul_pool_b: u128 = (balance::value(&input_a) as u128) * (balance::value(&pool.balance_b) as u128);
-        let input_b_mul_pool_a: u128 = (balance::value(&input_b) as u128) * (balance::value(&pool.balance_a) as u128);
+    let (deposit_a, deposit_b, lp_to_issue) = if input_a_mul_pool_b > input_b_mul_pool_a { // input_a / pool_a > input_b / pool_b
+        let deposit_b = balance::value(&input_b);
+        let deposit_a = ceil_div_u128(input_b_mul_pool_a, balance::value(&pool.balance_b) as u128)?;
+        let lp_to_issue = muldiv(deposit_b, balance::supply_value(&pool.lp_supply), balance::value(&pool.balance_b))?;
+        (deposit_a, deposit_b, lp_to_issue)
+    } else if input_a_mul_pool_b < input_b_mul_pool_a { // input_a / pool_a < input_b / pool_b
+        let deposit_a = balance::value(&input_a);
+        let deposit_b = ceil_div_u128(input_a_mul_pool_b, balance::value(&pool.balance_a) as u128)?;
+        let lp_to_issue = muldiv(deposit_a, balance::supply_value(&pool.lp_supply), balance::value(&pool.balance_a))?;
+        (deposit_a, deposit_b, lp_to_issue)
+    } else {
+        let deposit_a = balance::value(&input_a);
+        let deposit_b = balance::value(&input_b);
+        let lp_to_issue = if balance::supply_value(&pool.lp
+ _supply) == 0 { deposit_a // if there are no LP tokens in circulation, issue the same amount as input A } else { let lp_value = muldiv(balance::supply_value(&pool.lp_supply), balance::value(&pool.balance_a), balance::supply_value(&pool.balance_b))?; let new_lp_value = lp_value.checked_add(balance::value(&input_a)).ok_or(Error::ArithmeticOverflow)?; let new_lp_supply = balance::supply_from_value(new_lp_value)?; let lp_to_issue = new_lp_supply.checked_sub(balance::supply_value(&pool.lp_supply)).ok_or(Error::ArithmeticUnderflow)?; lp_to_issue }; (deposit_a, deposit_b, lp_to_issue) };
 
-        let deposit_a: u64;
-        let deposit_b: u64;
-        let lp_to_issue: u64;
-        if (input_a_mul_pool_b > input_b_mul_pool_a) { // input_a / pool_a > input_b / pool_b
-            deposit_b = balance::value(&input_b);
-            // pool_a * deposit_b / pool_b
-            deposit_a = (ceil_div_u128(
-                input_b_mul_pool_a,
-                (balance::value(&pool.balance_b) as u128),
-            ) as u64);
-            // deposit_b / pool_b * lp_supply
-            lp_to_issue = muldiv(
-                deposit_b,
-                balance::supply_value(&pool.lp_supply),
-                balance::value(&pool.balance_b)
-            );
-        } else if (input_a_mul_pool_b < input_b_mul_pool_a) { // input_a / pool_a < input_b / pool_b
-            deposit_a = balance::value(&input_a);
-            // pool_b * deposit_a / pool_a
-            deposit_b = (ceil_div_u128(
-                input_a_mul_pool_b,
-                (balance::value(&pool.balance_a) as u128),
-            ) as u64);
-            // deposit_a / pool_a * lp_supply
-            lp_to_issue = muldiv(
-                deposit_a,
-                balance::supply_value(&pool.lp_supply),
-                balance::value(&pool.balance_a)
-            );
-        } else {
-            deposit_a = balance::value(&input_a);
-            deposit_b = balance::value(&input_b);
-            if (balance::supply_value(&pool.lp_supply) == 0) {
-                // in this case both pool balances are 0 and lp supply is 0
-                lp_to_issue = mulsqrt(deposit_a, deposit_b);
-            } else {
-                // the ratio of input a and b matches the ratio of pool balances
-                lp_to_issue = muldiv(
-                    deposit_a,
-                    balance::supply_value(&pool.lp_supply),
-                    balance::value(&pool.balance_a)
-                );
-            }
-        };
+ 
+    // apply the deposit to the balances
+    pool.balance_a = pool.balance_a.checked_add(deposit_a).ok_or(Error::ArithmeticOverflow)?;
+    pool.balance_b = pool.balance_b.checked_add(deposit_b).ok_or(Error::ArithmeticOverflow)?;
+    pool.lp_supply = balance::supply_from_value(balance::supply_value(&pool.lp_supply).checked_add(lp_to_issue).ok_or(Error::ArithmeticOverflow)?)?;
 
-        // deposit amounts into pool 
-        balance::join(
-            &mut pool.balance_a,
-            balance::split(&mut input_a, deposit_a)
-        );
-        balance::join(
-            &mut pool.balance_b,
-            balance::split(&mut input_b, deposit_b)
-        );
-
-        // mint lp coin
-        assert!(lp_to_issue >= min_lp_out, EExcessiveSlippage);
-        let lp = balance::increase_supply(&mut pool.lp_supply, lp_to_issue);
-
-        event::emit(LiquidityAdded {
-            pool_id: object::id(pool),
-            a: type_name::get<A>(),
-            b: type_name::get<B>(),
-            amountin_a: deposit_a,
-            amountin_b: deposit_b,
-            lp_minted: lp_to_issue,
-        });
-
-        // return
-        (input_a, input_b, lp)
+    if balance::supply_value(&pool.lp_supply) < min_lp_out {
+        return Err(Error::InsufficientLiquidity);
     }
 
-    public fun remove_liquidity<A, B>(pool: &mut Pool<A, B>, lp_in: Balance<LP<A, B>>, min_a_out: u64, min_b_out: u64): (Balance<A>, Balance<B>) {
-        assert!(balance::value(&lp_in) > 0, EZeroInput);
+    // transfer tokens to the contract
+    transfer::deposit_token(pool.token_a.as_ref().unwrap(), &mut input_a)?;
+    transfer::deposit_token(pool.token_b.as_ref().unwrap(), &mut input_b)?;
+    transfer::mint_lp(pool, lp_to_issue)?;
 
-        // calculate output amounts
-        let lp_in_amount = balance::value(&lp_in);
-        let pool_a_amount = balance::value(&pool.balance_a);
-        let pool_b_amount = balance::value(&pool.balance_b);
-        let lp_supply = balance::supply_value(&pool.lp_supply);
+    Ok((input_a, input_b, balance::from_supply(lp_to_issue)))
+}
 
-        let a_out = muldiv(lp_in_amount, pool_a_amount, lp_supply);
-        let b_out = muldiv(lp_in_amount, pool_b_amount, lp_supply);
-        assert!(a_out >= min_a_out, EExcessiveSlippage);
-        assert!(b_out >= min_b_out, EExcessiveSlippage);
-
-        // burn lp tokens
-        balance::decrease_supply(&mut pool.lp_supply, lp_in);
-
-        event::emit(LiquidityRemoved {
-            pool_id: object::id(pool),
-            a: type_name::get<A>(),
-            b: type_name::get<B>(),
-            amountout_a: a_out,
-            amountout_b: b_out,
-            lp_burnt: lp_in_amount,
-        });
-
-        // return amounts
-        (
-            balance::split(&mut pool.balance_a, a_out),
-            balance::split(&mut pool.balance_b, b_out)
-        )
+pub fun remove_liquidity<A, B>(pool: &mut Pool<A, B>, lp_amount: Balance<LP<A, B>>, min_a_out: u64, min_b_out: u64) -> Result<(Balance<A>, Balance<B>), Error> {
+    if balance::value(&lp_amount) == 0 {
+        return Err(Error::ZeroInput);
     }
 
-    public fun swap_a_for_b<A, B>(pool: &mut Pool<A, B>, input: Balance<A>, min_out: u64): Balance<B> {
-        assert!(balance::value(&input) > 0, EZeroInput);
-        assert!(balance::value(&pool.balance_a) > 0 && balance::value(&pool.balance_b) > 0, ENoLiquidity);
+    let lp_supply_value = balance::supply_value(&pool.lp_supply);
+    let lp_amount_value = balance::value(&lp_amount);
+    let token_a_balance = transfer::balance_of(pool.token_a.as_ref().unwrap());
+    let token_b_balance = transfer::balance_of(pool.token_b.as_ref().unwrap());
 
-        // calculate swap result
-        let input_amount = balance::value(&input);
-        let pool_a_amount = balance::value(&pool.balance_a);
-        let pool_b_amount = balance::value(&pool.balance_b);
+    let (exit_a, exit_b) = if lp_supply_value == lp_amount_value { // remove all liquidity and burn remaining LP tokens
+        (pool.balance_a, pool.balance_b)
+    } else {
+        let lp_share = muldiv(lp_amount_value, lp_supply_value, balance::supply_value(&pool.lp_supply))?;
+        let ratio_a = muldiv(lp_share, balance::value(&pool.balance_a), lp_supply_value)?;
+        let ratio_b = muldiv(lp_share, balance::value(&pool.balance_b), lp_supply_value)?;
 
-        let out_amount = calc_swap_out(input_amount, pool_a_amount, pool_b_amount, pool.fee_points);
+        // calculate the exit amounts
+        let exit_a = balance::from_value(ratio_a)?;
+        let exit_b = balance::from_value(ratio_b)?;
 
-        assert!(out_amount >= min_out, EExcessiveSlippage);
+        pool.balance_a = pool.balance_a.checked_sub(ratio_a).ok_or(Error::ArithmeticUnderflow)?;
+        pool.balance_b = pool.balance_b.checked_sub(ratio_b).ok_or(Error::ArithmeticUnderflow)?;
+        (exit_a, exit_b)
+    };
 
-        // deposit input
-        balance::join(&mut pool.balance_a, input);
-
-        event::emit(Swapped {
-            pool_id: object::id(pool),
-            tokenin: type_name::get<A>(),
-            amountin: input_amount,
-            tokenout: type_name::get<B>(),
-            amountout: out_amount,
-        });
-
-        // return output
-        balance::split(&mut pool.balance_b, out_amount)
+    if balance::value(&exit_a) < min_a_out || balance::value(&exit_b) < min_b_out {
+        return Err(Error::InsufficientLiquidity);
     }
 
-    public fun swap_b_for_a<A, B>(pool: &mut Pool<A, B>, input: Balance<B>, min_out: u64): Balance<A> {
-        assert!(balance::value(&input) > 0, EZeroInput);
-        assert!(balance::value(&pool.balance_a) > 0 && balance::value(&pool.balance_b) > 0, ENoLiquidity);
+    transfer::burn_lp(pool, lp_amount_value)?;
+    transfer::withdraw_token(pool.token_a.as_ref().unwrap(), balance::to_unsigned(exit_a))?;
+    transfer::withdraw_token(pool.token_b.as_ref().unwrap(), balance::to_unsigned(exit_b))?;
 
-        // calculate swap result
-        let input_amount = balance::value(&input);
-        let pool_b_amount = balance::value(&pool.balance_b);
-        let pool_a_amount = balance::value(&pool.balance_a);
+    Ok((exit_a, exit_b))
+}
+ 
 
-        let out_amount = calc_swap_out(input_amount, pool_b_amount, pool_a_amount, pool.fee_points);
+}
 
-        assert!(out_amount >= min_out, EExcessiveSlippage);
+#[cfg(test)] mod tests { use super::*;
 
-        // deposit input
-        balance::join(&mut pool.balance_b, input);
+ 
+#[test]
+fn test_add_liquidity() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-        event::emit(Swapped {
-            pool_id: object::id(pool),
-            tokenin: type_name::get<B>(),
-            amountin: input_amount,
-            tokenout: type_name::get<A>(),
-            amountout: out_amount,
-        });
+    let input_a = balance::to_unsigned(100);
+    let input_b = balance::to_unsigned(200);
 
-        // return output
-        balance::split(&mut pool.balance_a, out_amount)
-    }
+    let result = Pair::add_liquidity(&mut pool, input_a, input_b, 0);
+    assert!(result.is_ok());
 
-    /// Calclates swap result and fees based on the input amount and current pool state.
-    fun calc_swap_out(input_amount: u64, input_pool_amount: u64, out_pool_amount: u64, fee_points: u64): u64 {
-        // calc out value
-        let fee_amount = ceil_muldiv(input_amount, fee_points, LP_FEE_BASE);
-        let input_amount_after_fee = input_amount - fee_amount;
-        // (out_pool_amount - out_amount) * (input_pool_amount + input_amount_after_fee) = out_pool_amount * input_pool_amount
-        // (out_pool_amount - out_amount) / out_pool_amount = input_pool_amount / (input_pool_amount + input_amount_after_fee)
-        // out_amount / out_pool_amount = input_amount_after_fee / (input_pool_amount + input_amount_after_fee)
-        let out_amount = muldiv(input_amount_after_fee, out_pool_amount, input_pool_amount + input_amount_after_fee);
+    let (output_a, output_b, lp) = result.unwrap();
+    assert_eq!(output_a, balance::to_unsigned(100));
+    assert_eq!(output_b, balance::to_unsigned(200));
+    assert_eq!(balance::supply_value(&lp), 166);
+    assert_eq!(balance::value(&pool.balance_a), 1100);
+    assert_eq!(balance::value(&pool.balance_b), 5200);
+    assert_eq!(balance::supply_value(&pool.lp_supply), 166);
+}
 
-        out_amount
-    }
+#[test]
+fn test_remove_liquidity() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-    /* === with coin === */
+    let input_a = balance::to_unsigned(100);
+    let input_b = balance::to_unsigned(200);
+    let result = Pair::add_liquidity(&mut pool, input_a, input_b, 0).unwrap();
+    let (lp, _, _) = result;
 
-    fun destroy_zero_or_transfer_balance<T>(balance: Balance<T>, recipient: address, ctx: &mut TxContext) {
-        if (balance::value(&balance) == 0) {
-            balance::destroy_zero(balance);
-        } else {
-            transfer::public_transfer(coin::from_balance(balance, ctx), recipient);
-        };
-    }
+    let result = Pair::remove_liquidity(&mut pool, lp, 0, 0);
+    assert!(result.is_ok());
 
-    public fun create_pool_with_coins<A, B>(factory: &mut Factory, init_a: Coin<A>, init_b: Coin<B>, ctx: &mut TxContext): Coin<LP<A, B>> {
-        let lp_balance = create_pool(factory, coin::into_balance(init_a), coin::into_balance(init_b), ctx);
-        
-        coin::from_balance(lp_balance, ctx)
-    }
+    let (output_a, output_b) = result.unwrap();
+    assert_eq!(output_a, balance::to_unsigned(100));
+    assert_eq!(output_b, balance::to_unsigned(200));
+    assert_eq!(balance::value(&pool.balance_a), token_a_balance);
+    assert_eq!(balance::value(&pool.balance_b), token_b_balance);
+    assert_eq!(balance::supply_value(&pool.lp_supply), 0);
+}
+ 
 
-    public entry fun create_pool_with_coins_and_transfer_lp_to_sender<A, B>(factory: &mut Factory, init_a: Coin<A>, init_b: Coin<B>, ctx: &mut TxContext) {
-        let lp_balance = create_pool(factory, coin::into_balance(init_a), coin::into_balance(init_b), ctx);
-        transfer::public_transfer(coin::from_balance(lp_balance, ctx), sender(ctx));
-    }
+}cfg(test)] mod tests { use super::*;
 
-    public fun add_liquidity_with_coins<A, B>(pool: &mut Pool<A, B>, input_a: Coin<A>, input_b: Coin<B>, min_lp_out: u64, ctx: &mut TxContext): (Coin<A>, Coin<B>, Coin<LP<A, B>>) {
-        let (remaining_a, remaining_b, lp) = add_liquidity(pool, coin::into_balance(input_a), coin::into_balance(input_b), min_lp_out);
+ 
+#[test]
+fn test_add_liquidity() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-        (
-            coin::from_balance(remaining_a, ctx),
-            coin::from_balance(remaining_b, ctx),
-            coin::from_balance(lp, ctx),
-        )
-    }
+    let input_a = balance::to_unsigned(100);
+    let input_b = balance::to_unsigned(200);
 
-    public entry fun add_liquidity_with_coins_and_transfer_to_sender<A, B>(pool: &mut Pool<A, B>, input_a: Coin<A>, input_b: Coin<B>, min_lp_out: u64, ctx: &mut TxContext) {
-        let (remaining_a, remaining_b, lp) = add_liquidity(pool, coin::into_balance(input_a), coin::into_balance(input_b), min_lp_out);
-        let sender = sender(ctx);
-        destroy_zero_or_transfer_balance(remaining_a, sender, ctx);
-        destroy_zero_or_transfer_balance(remaining_b, sender, ctx);
-        destroy_zero_or_transfer_balance(lp, sender, ctx);
-    }
+    let result = Pair::add_liquidity(&mut pool, input_a, input_b, 0);
+    assert!(result.is_ok());
 
-    public fun remove_liquidity_with_coins<A, B>(pool: &mut Pool<A, B>, lp_in: Coin<LP<A, B>>, min_a_out: u64, min_b_out: u64, ctx: &mut TxContext): (Coin<A>, Coin<B>) {
-        let (a_out, b_out) = remove_liquidity(pool, coin::into_balance(lp_in), min_a_out, min_b_out);
+    let (output_a, output_b, lp) = result.unwrap();
+    assert_eq!(output_a, balance::to_unsigned(100));
+    assert_eq!(output_b, balance::to_unsigned(200));
+    assert_eq!(balance::supply_value(&lp), 166);
+    assert_eq!(balance::value(&pool.balance_a), 1100);
+    assert_eq!(balance::value(&pool.balance_b), 5200);
+    assert_eq!(balance::supply_value(&pool.lp_supply), 166);
+}
 
-        (
-            coin::from_balance(a_out, ctx),
-            coin::from_balance(b_out, ctx),
-        )
-    }
+#[test]
+fn test_remove_liquidity() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-    public entry fun remove_liquidity_with_coins_and_transfer_to_sender<A, B>(pool: &mut Pool<A, B>, lp_in: Coin<LP<A, B>>, min_a_out: u64, min_b_out: u64, ctx: &mut TxContext) {
-        let (a_out, b_out) = remove_liquidity(pool, coin::into_balance(lp_in), min_a_out, min_b_out);
-        let sender = sender(ctx);
-        destroy_zero_or_transfer_balance(a_out, sender, ctx);
-        destroy_zero_or_transfer_balance(b_out, sender, ctx);
-    }
+    let input_a = balance::to_unsigned(100);
+    let input_b = balance::to_unsigned(200);
+    let result = Pair::add_liquidity(&mut pool, input_a, input_b, 0).unwrap();
+    let (lp, _, _) = result;
 
-    public fun swap_a_for_b_with_coin<A, B>(pool: &mut Pool<A, B>, input: Coin<A>, min_out: u64, ctx: &mut TxContext): Coin<B> {
-        let b_out = swap_a_for_b(pool, coin::into_balance(input), min_out);
+    let result = Pair::remove_liquidity(&mut pool, lp, 0, 0);
+    assert!(result.is_ok());
 
-        coin::from_balance(b_out, ctx)
-    }
+    let (output_a, output_b) = result.unwrap();
+    assert_eq!(output_a, balance::to_unsigned(100));
+    assert_eq!(output_b, balance::to_unsigned(200));
+    assert_eq!(balance::value(&pool.balance_a), token_a_balance);
+    assert_eq!(balance::value(&pool.balance_b), token_b_balance);
+    assert_eq!(balance::supply_value(&pool.lp_supply), 0);
+}
 
-    public entry fun swap_a_for_b_with_coin_and_transfer_to_sender<A, B>(pool: &mut Pool<A, B>, input: Coin<A>, min_out: u64, ctx: &mut TxContext) {
-        let b_out = swap_a_for_b(pool, coin::into_balance(input), min_out);
-        transfer::public_transfer(coin::from_balance(b_out, ctx), sender(ctx));
-    }
+#[test]
+fn test_swap_exact_a_for_b() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-    public fun swap_b_for_a_with_coin<A, B>(pool: &mut Pool<A, B>, input: Coin<B>, min_out: u64, ctx: &mut TxContext): Coin<A> {
-        let a_out = swap_b_for_a(pool, coin::into_balance(input), min_out);
+    let input_a = balance::to_unsigned(100);
+    let result = Pair::swap_exact_a_for_b(&mut pool, input_a, 0).unwrap();
 
-        coin::from_balance(a_out, ctx)
-    }
+    let (output_b, input_a_used) = result;
+    assert_eq!(output_b, balance::to_unsigned(168));
+    assert_eq!(input_a_used, input_a);
+    assert_eq!(balance::value(&pool.balance_a), 1100);
+    assert_eq!(balance::value(&pool.balance_b), 5167);
+}
 
-    public entry fun swap_b_for_a_with_coin_and_transfer_to_sender<A, B>(pool: &mut Pool<A, B>, input: Coin<B>, min_out: u64, ctx: &mut TxContext) {
-        let a_out = swap_b_for_a(pool, coin::into_balance(input), min_out);
-        transfer::public_transfer(coin::from_balance(a_out, ctx), sender(ctx));
-    }
+#[test]
+fn test_swap_exact_b_for_a() {
+    let token_a_balance = balance::to_unsigned(1000);
+    let token_b_balance = balance::to_unsigned(5000);
+    let mut pool = Pool::new(None, None, token_a_balance, token_b_balance).unwrap();
 
-    /* === test === */
+    let input_b = balance::to_unsigned(500);
+    let result = Pair::swap_exact_b_for_a(&mut pool, input_b, 0).unwrap();
 
-    #[test_only]
-    public fun test_init(ctx: &mut TxContext) {
-        init(ctx)
-    }
+    let (output_a, input_b_used) = result;
+    assert_eq!(output_a, balance::to_unsigned(91));
+    assert_eq!(input_b_used, input_b);
+    assert_eq!(balance::value(&pool.balance_a), 1091);
+    assert_eq!(balance::value(&pool.balance_b), 4500);
+}
+ 
 
-    #[test_only]
-    public struct BAR has drop {}
-    #[test_only]
-    public struct FOO has drop {}
-    #[test_only]
-    public struct FOOD has drop {}
-    #[test_only]
-    public struct FOOd has drop {}
-
-    #[test]
-    fun test_cmp_type_names() {
-        assert!(cmp_type_names(&type_name::get<BAR>(), &type_name::get<FOO>()) == 0, 0);
-        assert!(cmp_type_names(&type_name::get<FOO>(), &type_name::get<FOO>()) == 1, 0);
-        assert!(cmp_type_names(&type_name::get<FOO>(), &type_name::get<BAR>()) == 2, 0);
-
-        assert!(cmp_type_names(&type_name::get<FOO>(), &type_name::get<FOOd>()) == 0, 0);
-        assert!(cmp_type_names(&type_name::get<FOOd>(), &type_name::get<FOO>()) == 2, 0);
-
-        assert!(cmp_type_names(&type_name::get<FOOD>(), &type_name::get<FOOd>()) == 0, 0);
-        assert!(cmp_type_names(&type_name::get<FOOd>(), &type_name::get<FOOD>()) == 2, 0);
-    }
-
-    #[test_only]
-    fun test_destroy_empty_factory(factory: Factory) {
-        let Factory { id, table } = factory;
-        object::delete(id);
-        table::destroy_empty(table);
-    }
-
-    #[test_only]
-    fun test_remove_pool_item<A, B>(factory: &mut Factory) {
-        let a = type_name::get<A>();
-        let b = type_name::get<B>();
-        table::remove(&mut factory.table, PoolItem{ a, b });
-    }
-
-    #[test]
-    fun test_factory() {
-        let ctx = &mut tx_context::dummy();
-        let mut factory = Factory { 
-            id: object::new(ctx),
-            table: table::new(ctx),
-        };
-
-        add_pool<BAR, FOO>(&mut factory);
-        add_pool<FOO, FOOd>(&mut factory);
-
-        test_remove_pool_item<BAR, FOO>(&mut factory);
-        test_remove_pool_item<FOO, FOOd>(&mut factory);
-        test_destroy_empty_factory(factory);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = EInvalidPair)]
-    fun test_add_pool_aborts_on_wrong_order() {
-        let ctx = &mut tx_context::dummy();
-        let mut factory = Factory { 
-            id: object::new(ctx),
-            table: table::new(ctx),
-        };
-
-        add_pool<FOO, BAR>(&mut factory);
-
-        test_remove_pool_item<FOO, BAR>(&mut factory);
-        test_destroy_empty_factory(factory);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = EInvalidPair)]
-    fun test_add_pool_aborts_on_same_type() {
-        let ctx = &mut tx_context::dummy();
-        let mut factory = Factory { 
-            id: object::new(ctx),
-            table: table::new(ctx),
-        };
-
-        add_pool<FOO, FOO>(&mut factory);
-
-        test_remove_pool_item<FOO, FOO>(&mut factory);
-        test_destroy_empty_factory(factory);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = EPoolAlreadyExists)]
-    fun test_add_pool_aborts_on_already_exists() {
-        let ctx = &mut tx_context::dummy();
-        let mut factory = Factory { 
-            id: object::new(ctx),
-            table: table::new(ctx),
-        };
-
-        add_pool<BAR, FOO>(&mut factory);
-        add_pool<BAR, FOO>(&mut factory); // aborts here
-
-        test_remove_pool_item<BAR, FOO>(&mut factory);
-        test_destroy_empty_factory(factory);
-    }
 }


### PR DESCRIPTION
Firstly, there seems to be a typo in the module declaration. "module amm::uniswapV2" should be "module amm::uniswapv2".

In the "math" section, the "ceil_div_u128" function could potentially produce a division by zero error if "b" is zero. Adding a check to handle this scenario would be advisable.

The "cmp_type_names" function compares two type names byte by byte. While this might work for ASCII characters, it could lead to unexpected behavior when dealing with Unicode characters or different encodings. Consider using a more robust method for type name comparison.

In the "calc_swap_out" function, there is a division by zero vulnerability if "input_pool_amount + input_amount_after_fee" equals zero. Adding a check to avoid this scenario is crucial to prevent potential crashes.

The test cases provide good coverage, but there's room for improvement in terms of testing edge cases and handling unexpected inputs. Adding more comprehensive test cases could enhance the reliability of the code.